### PR TITLE
Fix mcode

### DIFF
--- a/src/xs/Kcode/libkcode/make.sh
+++ b/src/xs/Kcode/libkcode/make.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-OPT="-fPIC -O2 -Wuninitialized -march=i686 "
+OPT="-fPIC -O2 -Wuninitialized"
 
 rm -f *.o
 rm -f libkcode.a

--- a/src/xs/Mcode/libmcode/make.sh
+++ b/src/xs/Mcode/libmcode/make.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-OPT="-fPIC -O2 -Wuninitialized -march=i686 "
+OPT="-fPIC -O2 -Wuninitialized"
 
 rm -f *.o
 rm -f libmcode.a


### PR DESCRIPTION
compile_templateが動作しない。
原因はMCodeがコンパイルに失敗して、インストールできていないから。
コンパイルできるようになんとかする。
