### PR TITLE
Fix xs compile error

### DIFF
--- a/src/xs/Kcode/libkcode/make.sh
+++ b/src/xs/Kcode/libkcode/make.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-OPT="-fPIC -O2 -Wuninitialized -march=i686 "
+OPT="-fPIC -O2 -Wuninitialized"
 
 rm -f *.o
 rm -f libkcode.a

--- a/src/xs/Mcode/libmcode/make.sh
+++ b/src/xs/Mcode/libmcode/make.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-OPT="-fPIC -O2 -Wuninitialized -march=i686 "
+OPT="-fPIC -O2 -Wuninitialized"
 
 rm -f *.o
 rm -f libmcode.a


### PR DESCRIPTION
McodeとKcodeがコンパイルエラーだったので修正します。

原因はgccのオプションの`-march`でした。
このオプションは指定したCPU用の命令を出力するもので、クロスコンパイル用のものです。
実機でコンパイルするので、ここでは不要でした。