### PR TITLE
端末タイプPを表示する

### DIFF
--- a/pm/HTMLTemplate.pm
+++ b/pm/HTMLTemplate.pm
@@ -53,12 +53,12 @@ our %SMALL_TAG_END = (
 
 sub insert {
 	my ($name, $rhParams, $rhParams2) = @_;
-	
+
 	$rhParams  = {} unless ($rhParams);
 	$rhParams2 = {} unless ($rhParams2);
-	
+
 	# 会員フラグ
-	
+
 	if ($_::U->{USER_ID}) {
 		$rhParams2->{MEMBER} = 1;
 		$rhParams2->{USER_ID}  = $_::U->{USER_ID};
@@ -69,7 +69,7 @@ sub insert {
 			delete($rhParams2->{$key});
 		}
 	}
-	
+
 	$rhParams2->{RAND} = rand();
 	$rhParams2->{TIME} = time();
 	$rhParams2->{TEST} = 1 if ($_::TEST_MODE);
@@ -77,10 +77,10 @@ sub insert {
 		{ host => $ENV{MB_HTTP_HOST} });
 	$rhParams2->{SSLBasePath} = Request::makeSSLBasePath(
 		{ host => $ENV{MB_HTTPS_HOST} });
-	
+
 	# 端末の文字サイズ設定が「標準」でも「小」でも同じサイズで
 	# 表示できるようにするために使用
-	
+
 	if ($ENV{MB_CHARS_W} < 28) { # フォントサイズが標準以上の場合だけ
 		$rhParams2->{SMALL_TAG} =
 			$SMALL_TAG_M{$ENV{MB_MODEL_NAME}} ?
@@ -88,23 +88,24 @@ sub insert {
 			$SMALL_TAG_C{$ENV{MB_CARRIER_UA}};
 		$rhParams2->{SMALL_TAG_END} = $SMALL_TAG_END{$ENV{MB_CARRIER_UA}};
 	}
-	
+
 	# MobileEnv.pm で取得した内容
-	
+
 	$rhParams2->{CARRIER}     = $ENV{MB_CARRIER_UA};
 	$rhParams2->{MODEL_TYPE}  = $ENV{MB_MODEL_TYPE};
 	$rhParams2->{MODEL_NAME}  = $ENV{MB_MODEL_NAME};
 	$rhParams2->{BROWSER_W}   = $ENV{MB_BROWSER_W};
 	$rhParams2->{BROWSER_W2}  = $ENV{MB_BROWSER_W2};
 	$rhParams2->{CHARS_W}     = $ENV{MB_CHARS_W};
-	
+
 	# テンプレート処理
-	
-	my $type = lc($ENV{MB_CARRIER_UA});
+
+	# my $type = lc($ENV{MB_CARRIER_UA});
+  my $type = 'p';
 	my $html = MTemplate::insert(
 		"$_::HTML_BIN_DIR/_system/$name.bin.$type",
 			$rhParams, $rhParams2, $_::DEFAULT_CONFIG);
-	
+
 	return($html);
 }
 

--- a/pm/Page/Main.pm
+++ b/pm/Page/Main.pm
@@ -82,14 +82,6 @@ sub main {
 		}
 
 		#-------------------------------
-		# PC リダイレクト
-
-		# if ($ENV{MB_CARRIER_UA} eq '-') {
-		# 	redirectToRightDomain();
-		# 	goto FUNC_END;
-		# }
-
-		#-------------------------------
 		# リダイレクト
 
 		if ($_::BYPASS_FUNC{$func} >= 1) { # リダイレクト除外

--- a/pm/Page/Main.pm
+++ b/pm/Page/Main.pm
@@ -58,23 +58,6 @@ sub main {
 		$ENV{MB_REQUIRED_HOST}  = '';
 
 		#-------------------------------
-		# 処理ホスト名チェック
-
-		# my $proto = $ENV{MB_SSL} ? 'https' : 'http';
-		# if ($_::BYPASS_FUNC{$func} < 1 &&
-		# 	(
-		# 	($ENV{MB_REQUIRED_PROTO} &&
-		# 	 $ENV{MB_REQUIRED_PROTO} ne $proto)
-		# 	||
-		# 	($ENV{MB_REQUIRED_HOST} &&
-		# 	 $ENV{MB_REQUIRED_HOST} ne $ENV{SERVER_NAME})
-		# 	)
-		# ) {
-		# 	redirectToRightDomain();
-		# 	goto FUNC_END;
-		# }
-
-		#-------------------------------
 		# 接続元チェック除外
 
 		if ($_::BYPASS_FUNC{$func} >= 2) {

--- a/pm/Page/Main.pm
+++ b/pm/Page/Main.pm
@@ -90,17 +90,6 @@ sub main {
 		# }
 
 		#-------------------------------
-		# 携帯UAがキャリアGW以外のIPからアクセスしてきた場合
-
-		if ($ENV{MB_CARRIER_UA} ne $ENV{MB_CARRIER_IP} &&
-			$ENV{MB_CARRIER_UA} ne '-' &&
-			$ENV{MB_CARRIER_IP} ne 'I' && # 社内
-			!$_::DEBUG_ALLOW_PC) {
-			$func = '.noprx';
-			goto FUNC_START;
-		}
-
-		#-------------------------------
 		# リダイレクト
 
 		if ($_::BYPASS_FUNC{$func} >= 1) { # リダイレクト除外

--- a/pm/Page/Main.pm
+++ b/pm/Page/Main.pm
@@ -111,16 +111,6 @@ sub main {
 		}
 
 		#-------------------------------
-		# 登録機種情報とアクセス機種情報が異なる場合
-
-		if ($_::U->{USER_ID} &&
-			$_::U->{REG_MODEL} ne $ENV{MB_MODEL_NAME}) {
-			Func::User::updateModel(
-				$_::U->{USER_ID}, $_::U->{REG_MODEL});
-			DA::commit();
-		}
-
-		#-------------------------------
 		# リダイレクト
 
 		if ($_::BYPASS_FUNC{$func} >= 1) { # リダイレクト除外

--- a/pm/Page/Main.pm
+++ b/pm/Page/Main.pm
@@ -100,16 +100,6 @@ sub main {
 			goto FUNC_START;
 		}
 
-		#---------------------------
-		# サポート外機種
-
-		if ($ENV{MB_SERV_LV} == -1) {
-			if (!$_::NOSUP_OK_FUNC{$func}) {
-				$func = '.nosup';
-				goto FUNC_START;
-			}
-		}
-
 		#-------------------------------
 		# リダイレクト
 

--- a/pm/Page/Main.pm
+++ b/pm/Page/Main.pm
@@ -155,18 +155,6 @@ sub callPage {
 	MLog::write("$_::LOG_DIR/debug", "Page infomation $reqUidSt, $reqUserSt, $reqServSt, $moduleName, $subName");
 
 	#---------------------------
-	# UID_ST 端末情報エラー
-
-	if ($_::U->{UID_ST} < $reqUidSt) {
-		MLog::write("$_::LOG_DIR/debug", "Error UID_ST");
-		if ($ENV{MB_CARRIER_UA} eq 'D' &&
-			$ENV{REQUEST_URI} !~ /[\?\&]guid=ON/) {
-			MException::throw({ REDIRECT2 => 1 });
-		}
-		MException::throw({ CHG_FUNC => '.nouid' });
-	}
-
-	#---------------------------
 	# SERV_ST サービスステータスチェック
 
 	if ($_::U->{SERV_ST} & $reqServSt) {


### PR DESCRIPTION
どの端末で来ても、フィーチャーフォン向けテンプレートバイナリを使わず、端末タイプPのもので表示する。