### PR TITLE
Fix authorization

### DIFF
--- a/conf/pages.conf
+++ b/conf/pages.conf
@@ -35,14 +35,14 @@ our %PAGE = (
 #-------------------
 # トップページ
 
-'.top'     => [ 2,0,0, 'Page::Top',    'pageMain'      ], # トップ
+'.top'     => [ 0,0,0, 'Page::Top',    'pageMain'      ], # トップ
 
 #-------------------
 # ユーザ登録
 
-'userShow'   => [ 2,0,0, 'Page::User', 'pageShow'      ], # show
-'userNew'    => [ 2,0,0, 'Page::User', 'pageNew'       ], # new
-'userCreate' => [ 2,0,0, 'Page::User', 'pageCreate'    ], # create
+'userShow'   => [ 0,0,0, 'Page::User', 'pageShow'      ], # show
+'userNew'    => [ 0,0,0, 'Page::User', 'pageNew'       ], # new
+'userCreate' => [ 0,0,0, 'Page::User', 'pageCreate'    ], # create
 
 );
 

--- a/pm/Page/Main.pm
+++ b/pm/Page/Main.pm
@@ -152,6 +152,17 @@ sub callPage {
 	MLog::write("$_::LOG_DIR/debug", "Page infomation $reqUidSt, $reqUserSt, $reqServSt, $moduleName, $subName");
 
 	#---------------------------
+	# UID_ST 端末情報エラー
+
+	if ($_::U->{UID_ST} < $reqUidSt) {
+		if ($ENV{MB_CARRIER_UA} eq 'D' &&
+			$ENV{REQUEST_URI} !~ /[\?\&]guid=ON/) {
+			MException::throw({ REDIRECT2 => 1 });
+		}
+		MException::throw({ CHG_FUNC => '.nouid' });
+	}
+
+	#---------------------------
 	# SERV_ST サービスステータスチェック
 
 	if ($_::U->{SERV_ST} & $reqServSt) {


### PR DESCRIPTION
Topページが見れなかったので削除してしまっていた、UID_ST 端末情報エラーの
部分を復元しました。
そもそもここは端末情報ではなく、ユーザが登録されているか？ユーザの状態を
チェックする箇所だったため、mobasifの認証機構を利用するためには必須
でした。