### PR TITLE
Extend wait time for mariadb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
       - run:
           name: waiting for mariadb to be ready
           command: |
-            for i in `seq 10`; do
+            for i in `seq 20`; do
               nc -z mariadb 3306 && echo Success && exit 0
               echo -n .
               sleep 1


### PR DESCRIPTION
よくCIでmariadbの接続待ちで失敗するので、待ち時間を長くしてみます。