### PR TITLE
Add status code in redirection response

### DIFF
--- a/pm/Response.pm
+++ b/pm/Response.pm
@@ -44,6 +44,7 @@ sub output {
 
 sub redirect {
 	my $url = shift;
+	print "Status: 302 Found\r\n";
 	print "Location: $url\r\n";
 	print "Connection: close\r\n";
 	_print_cookies($_::C);

--- a/test/pm/Response.t
+++ b/test/pm/Response.t
@@ -47,6 +47,7 @@ describe 'Response' => sub {
         my $url = "https://www.example.com/user/new";
         trap { Response::redirect($url) };
         my $stdout = $trap->stdout;
+        ok($stdout =~ /Status: 302 Found/);
         ok($stdout =~ /Location: $url/);
         ok($stdout =~ /Connection: close/);
       };
@@ -59,6 +60,7 @@ describe 'Response' => sub {
         my $url = "https://www.example.com/user/new";
         trap { Response::redirect($url) };
         my $stdout = $trap->stdout;
+        ok($stdout =~ /Status: 302 Found/);
         ok($stdout =~ /Location: $url/);
         ok($stdout =~ /Set-Cookie:foo=bar; path=\//);
         ok($stdout =~ /Connection: close/);


### PR DESCRIPTION
リダイレクトのレスポンスにステータスコードがついておらず、
リダイレクト先のページは表示されていたがURLがそのままになっていました。

↓をやっているときに発見しました。
https://github.com/ken1flan/mobasif_sample/pull/57
